### PR TITLE
Add support for more yaml files

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -97,7 +97,7 @@ book() {
 
   printf "${green}===> Merging secrets from settings.yml into the generated manifest ...${reset}"
 
-  export VAULT_ADDR="$(safe target 2>&1 | awk '{print $NF}')"
+  export VAULT_ADDR="$(safe target 2>&1 | sed 's/.* http\([^ ]*\) .*/http\1/')"
   export VAULT_TOKEN="$(safe vault token-renew --format=json | jq -r '.auth.client_token')"
   spruce --concourse merge --prune meta $pre_merged_manifest $FILES_TO_MERGE > $manifest
 

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -95,7 +95,12 @@ book() {
   echo "${green}done${reset}"
 
   printf "${green}===> Merging secrets from settings.yml into the generated manifest ...${reset}"
+
+  export VAULT_ADDR="$(safe targets 2>&1 |grep "(*)" | cut -d$'\t' -f2)"
+  export VAULT_TOKEN="$(safe vault token-renew --format=json | jq -r '.auth.client_token')"
   spruce --concourse merge --prune meta $pre_merged_manifest $FILES_TO_MERGE > $manifest
+
+
   echo "${green}done${reset}"
 
   fly -t concourse set-pipeline -c $manifest -p $NAME $fly_opts

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -97,7 +97,7 @@ book() {
 
   printf "${green}===> Merging secrets from settings.yml into the generated manifest ...${reset}"
 
-  export VAULT_ADDR="$(safe targets 2>&1 |grep "(*)" | cut -d$'\t' -f2)"
+  export VAULT_ADDR="$(safe target 2>&1 | awk '{print $NF}')"
   export VAULT_TOKEN="$(safe vault token-renew --format=json | jq -r '.auth.client_token')"
   spruce --concourse merge --prune meta $pre_merged_manifest $FILES_TO_MERGE > $manifest
 

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -60,7 +60,8 @@ EOM
 
 book() {
   TRAVEL_AGENT_CONFIG=$1
-  FILES_TO_MERGE=$2
+  shift
+  FILES_TO_MERGE=$@
 
   if [ -z "$TRAVEL_AGENT_CONFIG" ] ; then
     echo "${red}===> provide TAVEL_AGENT_CONFIG if you want to generate a manifest${reset}"
@@ -73,7 +74,7 @@ book() {
   fi
 
   if [ -n "$TRAVEL_AGENT_CONFIG" ] ; then
-    TRAVEL_AGENT_PROJECT=$(cat "$1" | grep -v -e "^#" | grep -e "^git_project:" |  awk -F"git_project:" '{print $2}' )
+    TRAVEL_AGENT_PROJECT=$(cat "$TRAVEL_AGENT_CONFIG" | grep -v -e "^#" | grep -e "^git_project:" |  awk -F"git_project:" '{print $2}' )
     clone_project "$TRAVEL_AGENT_PROJECT"
   fi
 

--- a/bin/travel-agent
+++ b/bin/travel-agent
@@ -73,7 +73,8 @@ if [[ $1 =~ ^(help|target|init|book)$ ]]; then
       init $2
       ;;
     book)
-      book $2 $3
+      shift
+      book $@
       ;;
   esac
 else


### PR DESCRIPTION
This allows travel agent to take multiple args in for merging, when booking pipelines, a first step in supporting the removal of `--concourse` when spruce merging (since that's deprecated)