### PR TITLE
Enables mergin resources from the travel-agent.yml configuration

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -1,28 +1,39 @@
-manifest=.tmp/concourse_deployment_manifest.yml
-pre_merged_manifest=.tmp/pre_merged_manifest.yml
-vendored_ego=$GOPATH/src/github.com/compozed/travel-agent/vendor/github.com/benbjohnson/ego/cmd/ego/main.go
+OUTPUT=.tmp
+VENDORED_EGO=$GOPATH/src/github.com/compozed/travel-agent/vendor/github.com/benbjohnson/ego/cmd/ego/main.go
 
-target(){
+red=`tput setaf 1`
+green=`tput setaf 2`
+yellow=`tput setaf 3`
+magenta=`tput setaf 5`
+reset=`tput sgr0`
+
+function log() {
+  printf "${green}$1${reset}"
+}
+
+function log_error() {
+  printf "${red}$1${reset}"
+}
+
+function target(){
   TARGET=$1
 
-  if [  -z "$TARGET" ]
-  then
-    echo "${red}You must provide a concourse target${reset}"
+  if [  -z "$TARGET" ]; then
+    log_error "You must provide a concourse target"
     echo ''
     echo 'USAGE: ./travel-agent target CONCOURSE_TARGET. eg: http://ATC_IP:8080'
     exit 1
   fi
 
-  fly -t concourse login -k -c $TARGET
+    fly -t concourse login -k -c $TARGET
 }
 
-# Clean old atifacts
-clean(){
-  rm -f manifest.go manifest 
+function clean(){
+  rm -f manifest.go manifest
 }
 
-clone_project(){
-  project_path=$1
+function clone_project(){
+  local project_path=$1
   echo $project_path
   if [ ! -z "$project_path" ] && [[ $1 == *".git" ]]  ; then
     project_dir=`basename $project_path .git`
@@ -55,32 +66,40 @@ Subcommands:
 help
 intit       - Generates and upgrades travel agent project
 target      - Sets concourse target. EG: https://1.2.3.4:9090
-book        - compiles and deploys manifest.ego (manifest.ego) 
+book        - compiles and deploys manifest.ego (manifest.ego)
 EOM
 }
 
-book() {
+function book() {
   TRAVEL_AGENT_CONFIG=$1
   shift
   FILES_TO_MERGE=$@
 
+  local manifest=$OUTPUT/concourse_deployment_manifest.yml
+  local pre_merged_manifest=$OUTPUT/pre_merged_manifest.yml
+
   if [ -z "$TRAVEL_AGENT_CONFIG" ] ; then
-    echo "${red}===> provide TAVEL_AGENT_CONFIG if you want to generate a manifest${reset}"
+    log_error "===> provide TAVEL_AGENT_CONFIG if you want to generate a manifest"
     exit 1
   fi
 
   if [ -z "$FILES_TO_MERGE" ] ; then
-    echo "${red}===> provide FILES_TO_MERGE if you want to spruce merge secrets to manifest${reset}"
+    log_error "$===> provide FILES_TO_MERGE if you want to spruce merge secrets to manifest"
     exit 1
   fi
 
   if [ -n "$TRAVEL_AGENT_CONFIG" ] ; then
-    TRAVEL_AGENT_PROJECT=$(cat "$TRAVEL_AGENT_CONFIG" | grep -v -e "^#" | grep -e "^git_project:" |  awk -F"git_project:" '{print $2}' )
+    TRAVEL_AGENT_PROJECT=$( \
+      cat "$TRAVEL_AGENT_CONFIG" | \
+      grep -v -e "^#" | \
+      grep -e "^git_project:" |  \
+      awk -F"git_project:" '{print $2}' )
+
     clone_project "$TRAVEL_AGENT_PROJECT"
   fi
 
   if ! [ -d "ci/manifest" ]; then
-    echo "This does not look like a travel agent project"
+    log_error "This does not look like a travel agent project"
     exit 1
   fi
 
@@ -88,24 +107,25 @@ book() {
 
   clean
 
-  printf "${green}===> Rendering the ${magenta}.ego${green} manifest...${reset}"
-  go run $vendored_ego -package main -o manifest.go
+  log "===> Rendering the ${magenta}.ego${green} manifest..."
+  go run $VENDORED_EGO -package main -o manifest.go
   NAME=$(grep -E "^name:" $TRAVEL_AGENT_CONFIG | awk -F " " '{print $2}')
   mkdir -p .tmp
   go run manifest.go main.go $TRAVEL_AGENT_CONFIG > $pre_merged_manifest
   echo "${green}done${reset}"
 
-  printf "${green}===> Authenticating to Vault via ${magenta}safe${green}...${reset}"
+  log "===> Authenticating to Vault via ${magenta}safe..."
   export VAULT_ADDR="$(cat ~/.svtoken | grep '^vault:' | cut -d " " -f2)"
   export VAULT_TOKEN="$(safe vault token-renew --format=json | jq -r '.auth.client_token')"
-  echo "${green}done${reset}"
+  log "done\n"
 
-  printf "${green}===> ${magenta}spruce${green} merging secrets from settings.yml into the generated manifest ...${reset}"
-  spruce merge --prune meta $pre_merged_manifest $FILES_TO_MERGE > $manifest
-  echo "${green}done${reset}"
+  log "===> ${magenta}spruce${green} merging secrets from settings.yml into the generated manifest ..."
+  spruce merge --prune meta --prune envs --prune git_project --prune name \
+    $TRAVEL_AGENT_CONFIG $pre_merged_manifest $FILES_TO_MERGE > $manifest
+  log "done\n"
 
-  echo "${green}===> Updating concourse pipeline configuration via ${magenta}fly${green}...${reset}"
-  fly -t concourse set-pipeline -c $manifest -p $NAME $fly_opts
+  log "===> Updating concourse pipeline configuration via ${magenta}fly${green}..."
+  fly -t concourse set-pipeline --check-creds -c $manifest -p $NAME $fly_opts
 
   popd > /dev/null
 }

--- a/bin/travel-agent
+++ b/bin/travel-agent
@@ -4,40 +4,35 @@ set -e
 
 source $GOPATH/src/github.com/compozed/travel-agent/bin/common.sh
 
-red=`tput setaf 1`
-green=`tput setaf 2`
-yellow=`tput setaf 3`
-magenta=`tput setaf 5`
-reset=`tput sgr0`
-
 conf_dir=~/.travel-agent
 
 init(){
   NAME=$1
 
+  local manifest_folder=$GOPATH/src/github.com/compozed/travel-agent/manifest
+
   if [  -z "$NAME" ]
   then
-    echo "${red}You must provide a concourse target${reset}"
+    log_error "You must provide a concourse target \n"
     echo ''
     echo 'USAGE: ./travel-agent init NAME'
     exit 1
   fi
 
-  manifest_folder=$GOPATH/src/github.com/compozed/travel-agent/manifest
   mkdir -p ci && cp -rn $manifest_folder ci/. 2>/dev/null || :
 }
 
 
 
-upgrade-travel-agent(){
-manifest_folder=$GOPATH/src/github.com/compozed/travel-agent/manifest
-mkdir -p ci && cp -rn $manifest_folder ci/. 2>/dev/null || :
+function upgrade-travel-agent(){
+  local manifest_folder=$GOPATH/src/github.com/compozed/travel-agent/manifest
+  mkdir -p ci && cp -rn $manifest_folder ci/. 2>/dev/null || :
 
-pushd ci/manifest > /dev/null
-cp $manifest_folder/manifest_test.go .
-cp $manifest_folder/manifest_suite_test.go .
-cp $manifest_folder/main.go .
-popd > /dev/null
+  pushd ci/manifest > /dev/null
+    cp $manifest_folder/manifest_test.go .
+    cp $manifest_folder/manifest_suite_test.go .
+    cp $manifest_folder/main.go .
+  popd > /dev/null
 
 }
 

--- a/manifest/travel-agent.yml
+++ b/manifest/travel-agent.yml
@@ -6,3 +6,7 @@ envs:
   features:
     check_for_existence: true
     grab_value: alwaysRetrieveThis
+resources:
+- name: resource-to-be-merged
+  source: {}
+  type: some-resource


### PR DESCRIPTION
more generic pipelines as resources specific to a product deployment can be set in the travel-agent.yml config and not in the manifest.ego.

Concourse allows inputs for tasks to be optional (https://concourse-ci.org/tasks.html#input-optional). In this way you can have a task that allows inputs A, B and C, but the travel-agent.yml config only pulls a subset of them.