### PR TITLE
Adds concourse team name to the target

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -3,7 +3,7 @@
 exec >&2
 set -e
 
-if [[ "${DEBUG,,}" == "true" ]]; then
+if [[ "${DEBUG}" == "true" ]]; then
   set -x
   echo "Environment Variables:"
   env

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -28,6 +28,7 @@ function log_error() {
 
 function target(){
   TARGET=$1
+  TEAM=$2
 
   if [  -z "$TARGET" ]; then
     log_error "You must provide a concourse target"
@@ -35,8 +36,12 @@ function target(){
     echo 'USAGE: ./travel-agent target CONCOURSE_TARGET. eg: http://ATC_IP:8080'
     exit 1
   fi
+  
+  if [ -z "$TEAM" ]; then
+    TEAM="main"
+  fi
 
-    fly -t concourse login -k -c $TARGET
+  fly -t concourse login -k -c $TARGET -n $TEAM
 }
 
 function clean(){

--- a/bin/travel-agent
+++ b/bin/travel-agent
@@ -63,7 +63,7 @@ if [[ $1 =~ ^(help|target|init|book)$ ]]; then
       help
       ;;
     target)
-      target $2
+      target $2 $3
       ;;
     init)
       init $2


### PR DESCRIPTION
Please let me know your thoughts on the following changes.
 - Changed `${DEBUG,,}` to `${DEBUG}` as it not compatible with the older version of bash on MacOS. Any other options to get it working?
 - Added an additional parameter to be able to specify a concourse team name to the `target` option